### PR TITLE
Add unit tests for metrics

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,41 @@
+import numpy as np
+from src.evaluate.metrics import compute_confusion_matrix, per_class_accuracy
+
+
+def test_compute_confusion_matrix_basic():
+    true_labels = [0, 1, 2, 1, 0, 2]
+    pred_labels = [0, 2, 1, 1, 0, 2]
+    cm = compute_confusion_matrix(true_labels, pred_labels, num_classes=3)
+    expected = np.array([
+        [2, 0, 0],
+        [0, 1, 1],
+        [0, 1, 1],
+    ])
+    assert np.array_equal(cm, expected)
+
+
+def test_per_class_accuracy_basic():
+    cm = np.array([
+        [2, 0, 0],
+        [0, 1, 1],
+        [0, 1, 1],
+    ])
+    acc = per_class_accuracy(cm)
+    expected = np.array([1.0, 0.5, 0.5])
+    assert np.allclose(acc, expected)
+
+
+def test_per_class_accuracy_with_zero_true_class():
+    true_labels = [0, 0, 1, 1, 1]
+    pred_labels = [0, 0, 1, 0, 1]
+    cm = compute_confusion_matrix(true_labels, pred_labels, num_classes=3)
+    expected_cm = np.array([
+        [2, 0, 0],
+        [1, 2, 0],
+        [0, 0, 0],
+    ])
+    assert np.array_equal(cm, expected_cm)
+
+    acc = per_class_accuracy(cm)
+    expected_acc = np.array([1.0, 2/3, 0.0])
+    assert np.allclose(acc, expected_acc)


### PR DESCRIPTION
## Summary
- add `tests/test_metrics.py` covering `compute_confusion_matrix` and `per_class_accuracy`
- check confusion matrix output and per-class accuracy
- ensure classes with no true samples return zero accuracy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845e48f6b6883248f14e557011a80a7